### PR TITLE
docs: update genesis_validators.md

### DIFF
--- a/mainnet/sidechain-1/genesis_validators.md
+++ b/mainnet/sidechain-1/genesis_validators.md
@@ -31,8 +31,7 @@ These instructions are for creating a basic setup of a single node. Validators s
 
 ```sh
 git clone https://github.com/sideprotocol/side.git
-git checkout v1.0.0-rc.1
-cd side
+cd side && git checkout v1.0.0-rc.1
 make install
 ```
 


### PR DESCRIPTION
Fix the error in the order of switching branches and directories in the documentation