### PR TITLE
docs: Fix subject-verb agreement in error message Update tss.md

### DIFF
--- a/mainnet/sidechain-1/tss.md
+++ b/mainnet/sidechain-1/tss.md
@@ -1,6 +1,6 @@
 # Shuttler
 
-**NOTE：ONLY Side Bridge operator need to run Shuttler**
+**NOTE: ONLY Side Bridge operator needs to run Shuttler**
 
 The *`TSS`*(**Threshold Signature Scheme**) network is a key building block intended to perform Bitcoin signing in the distributed manner to facilitate the Bitcoin bridge on the [Side Chain](https://github.com/sideprotocol/side)
 


### PR DESCRIPTION
A grammatical error in the error message where "operator need" should be corrected to "operator needs" since the subject "operator" requires a singular verb. This PR fixes that.

Thanks for Side Protocol! Love you!